### PR TITLE
Fix for command line to installation of NTLK

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are different ways to install nltk library. If you have experience with us
   - Choose IronPython environment and then choose _Packages (PyPi)_ from combobox below
   - Type there nltk and choose &#39;pip install nltk&#39;
   - After installing, make sure you have installed nltk folder at &lt;IronPython Path&gt;\Libs\site-packages\nltk
-- _From command line using pip._ Run &#39;pip install nltk&#39; from command line. Path to _Pip.exe_ have to be added to PATH environment variable. If you have several Python environments in system then, make sure you&#39;re installing _nltk_ library to IronPython path.
+- _From command line using pip._ Run &#39;pip install nltk==3.4.5&#39; from command line. Path to _Pip.exe_ have to be added to PATH environment variable. If you have several Python environments in system then, make sure you&#39;re installing _nltk_ library to IronPython path.
 - _From binaries._ Download binaries from [https://pypi.org/project/nltk/#files](https://pypi.org/project/nltk/#files). And run installer or unpack archive to &lt;IronPythonPath&gt;\Libs\site-packages\nltk. See [https://www.nltk.org/install.html](https://www.nltk.org/install.html) for more details.
 
 


### PR DESCRIPTION
The latest version of NTLK no longer supports Python 2.7, so the version to install now needs to be specified explicitly - 3.4.5

Note: the Visual Studio instructions now need to be updated, as well as instructions regarding installation "from binaries".